### PR TITLE
Missing dependency Str

### DIFF
--- a/src/Commands/Resources/ResourceFileFromDatabaseCommand.php
+++ b/src/Commands/Resources/ResourceFileFromDatabaseCommand.php
@@ -17,6 +17,7 @@ use CrestApps\CodeGenerator\Traits\Migration;
 use DB;
 use Exception;
 use File;
+use CrestApps\CodeGenerator\Support\Str;
 
 class ResourceFileFromDatabaseCommand extends ResourceFileCommandBase
 {


### PR DESCRIPTION
```
Class 'CrestApps\CodeGenerator\Commands\Resources\Str' not found
```